### PR TITLE
add 'archetypeName' as known rage::fwEntityDef field

### DIFF
--- a/Tools/MetaTool/Lists/StructureFieldNames.txt
+++ b/Tools/MetaTool/Lists/StructureFieldNames.txt
@@ -168,6 +168,7 @@ assetName
 audioId
 rotation
 normal
+archetypeName
 guid
 position
 InteriorNames


### PR DESCRIPTION
(blame github's online editor for the end-of-file newline)
